### PR TITLE
Added biblebox.ini

### DIFF
--- a/config/biblebox.ini
+++ b/config/biblebox.ini
@@ -1,0 +1,11 @@
+channel=11
+hostname=BibleBox.lan
+librarybox_ftpadmin="yes"
+librarybox_ftpanon="no"
+librarybox_ftpsyncport=54321
+librarybox_ftpsync=
+librarybox_ftp="yes"
+librarybox_shoutbox="yes"
+ssid=BibleBox files
+system_hostname=tLsGbQOW.BibleBox.lan
+txpower=25


### PR DESCRIPTION
admin/index.php reads from biblebox.ini instead of from the txt files with get_config(). save_config() still writes to txt files.